### PR TITLE
fix: simplify code review workflow to remove broken plugin setup

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+
+          # Original plugin-based setup (was causing exit code 1 errors):
+          # plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          # plugins: 'code-review@claude-code-plugins'
+          # prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+
+          prompt: |
+            Please review this pull request. Focus on:
+            - Bugs or logic errors
+            - Security issues
+            - Code quality and readability
+            - Any missing edge case handling
+            Post your review as a PR comment.
 


### PR DESCRIPTION
## Summary
- Removes the `plugin_marketplaces` + `plugins` config that was causing `exit code 1` errors
- Replaces with a direct `prompt` for Claude to review PRs
- Original plugin config kept as comments for reference

## Test plan
- [ ] Workflow triggers on this PR
- [ ] Claude posts a code review comment without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)