### PR TITLE
fix: grant pull-requests write permission for code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- Changes `pull-requests` permission from `read` to `write`
- Claude needs write access to post review comments on PRs

## Test plan
- [ ] Workflow triggers on this PR
- [ ] Claude successfully posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)