### PR TITLE
chore: disable automatic Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: false # disabled — set to true to re-enable automatic reviews
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
- Adds `if: false` to the `claude-review` job to prevent it from running on PRs
- To re-enable, remove the `if: false` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)