### PR TITLE
fix(perk): correct pipeline attainment distribution counts

### DIFF
--- a/business-cases/Perk/deck/Revenue_Operations_Case_Study.html
+++ b/business-cases/Perk/deck/Revenue_Operations_Case_Study.html
@@ -139,10 +139,10 @@
     ];
 
     const distributionData = [
-      { range: "0-25%", count: 3, color: COLORS.red },
-      { range: "25-50%", count: 4, color: COLORS.orange },
-      { range: "50-75%", count: 7, color: "#FACC15" },
-      { range: "75-100%", count: 14, color: COLORS.greenMid },
+      { range: "0-25%", count: 2, color: COLORS.red },
+      { range: "25-50%", count: 5, color: COLORS.orange },
+      { range: "50-75%", count: 5, color: "#FACC15" },
+      { range: "75-100%", count: 16, color: COLORS.greenMid },
       { range: "100%+", count: 18, color: COLORS.greenDark },
     ];
 

--- a/business-cases/Perk/deck/Revenue_Operations_Case_Study_Print.html
+++ b/business-cases/Perk/deck/Revenue_Operations_Case_Study_Print.html
@@ -176,10 +176,10 @@
     ];
 
     const distributionData = [
-      { range: "0-25%", count: 3, color: COLORS.red },
-      { range: "25-50%", count: 4, color: COLORS.orange },
-      { range: "50-75%", count: 7, color: "#FACC15" },
-      { range: "75-100%", count: 14, color: COLORS.greenMid },
+      { range: "0-25%", count: 2, color: COLORS.red },
+      { range: "25-50%", count: 5, color: COLORS.orange },
+      { range: "50-75%", count: 5, color: "#FACC15" },
+      { range: "75-100%", count: 16, color: COLORS.greenMid },
       { range: "100%+", count: 18, color: COLORS.greenDark },
     ];
 


### PR DESCRIPTION
## Summary

- Recomputes `distributionData` buckets by counting directly from the 46 fully ramped SDRs in `quadrantData`
- Previous values were stale (based on the old 12-entry dataset)

| Range | Before | After |
|-------|--------|-------|
| 0-25% | 3 | **2** |
| 25-50% | 4 | **5** |
| 50-75% | 7 | **5** |
| 75-100% | 14 | **16** |
| 100%+ | 18 | 18 ✓ |

Both `Revenue_Operations_Case_Study.html` and `Revenue_Operations_Case_Study_Print.html` updated.

## Test plan

- [ ] Open slide 4 ("SQL vs Pipeline Attainment (Fully Ramped)")
- [ ] Confirm the "Pipeline Attainment Distribution" bar chart matches the dot distribution in the scatterplot
- [ ] Total counts across all buckets = 46

🤖 Generated with [Claude Code](https://claude.com/claude-code)