### PR TITLE
Add yearly / presidential period tabs to Colombia sectors chart

### DIFF
--- a/colombia-economic-sectors/index.html
+++ b/colombia-economic-sectors/index.html
@@ -259,14 +259,17 @@ function initPeriodChart(){
       const realYears = p.name==='Petro' ? [2023,2024,2025] : p.years;
       return compound(realYears.map(yr=>getRate(s,yr)));
     }),
-    backgroundColor: s.color+'bb',
     borderColor: s.color,
-    borderWidth: 1,
-    borderRadius: 3,
+    backgroundColor: s.color+'15',
+    borderWidth: 2,
+    pointRadius: 5,
+    pointHoverRadius: 7,
+    tension: .35,
+    fill: false,
   }));
 
   periodChartInstance = new Chart(document.getElementById('periodChart').getContext('2d'),{
-    type:'bar',
+    type:'line',
     data:{ labels:periodLabels, datasets },
     options:{
       responsive:true, maintainAspectRatio:false,


### PR DESCRIPTION
## Summary

- Adds two tabs to the first chart card on the Colombia economic sectors page
- **Anual** tab: existing yearly line chart, unchanged, with government change markers
- **Período presidencial** tab: new line chart showing compound growth per sector across the 4 presidential periods (Santos I 2012–2014, Santos II 2015–2018, Duque 2019–2022, Petro 2023–2025), using the same data as Table 2

## Details

- Period chart uses the same `compound()` helper and sector colors as the rest of the page
- Petro uses real data only (2023–2025), no 2026 projection — noted below the chart
- Period chart initializes lazily on first tab click to avoid Chart.js sizing issues with hidden canvases

## Test plan

- [ ] Open `colombia-economic-sectors/index.html` in a browser
- [ ] Verify "Anual" tab shows the yearly line chart with government markers
- [ ] Click "Período presidencial" — chart renders with 6 sector lines across 4 periods
- [ ] Hover tooltip shows compound growth values per sector
- [ ] Switching back to "Anual" works correctly

https://claude.ai/code/session_011mFKCUVVqDiUEakFUfqR4v

---
_Generated by [Claude Code](https://claude.ai/code/session_011mFKCUVVqDiUEakFUfqR4v)_